### PR TITLE
Add .lock files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 old
 .old
+.~lock.*.ods#

--- a/.scripts/.~lock.an4.26.ods#
+++ b/.scripts/.~lock.an4.26.ods#
@@ -1,1 +1,0 @@
-,sujato,sujato-ThinkCentre-M725s,05.07.2020 08:19,file:///home/sujato/.config/libreoffice/4;

--- a/.scripts/.~lock.iti108.ods#
+++ b/.scripts/.~lock.iti108.ods#
@@ -1,1 +1,0 @@
-,sujato,sujato-ThinkCentre-M725s,05.07.2020 08:25,file:///home/sujato/.config/libreoffice/4;


### PR DESCRIPTION
I noticed a whole whack of other changes went in with the pvr2.9/10 fix (30f82f4) and the .ods files cleared out in the subsequent commit, but there are still .lock files in the .scripts directory.

Making a few unverified assumptions, this removes the .lock files and adds to .gitignore so they don't find their way in again.