### PR TITLE
Remove an incorrect variant

### DIFF
--- a/variant/pli/ms/sutta/dn/dn33_variant-pli-ms.json
+++ b/variant/pli/ms/sutta/dn/dn33_variant-pli-ms.json
@@ -39,7 +39,6 @@
   "dn33:2.2.106": "vigataṁ → vigate (sya-all, mr); vighātaṁ (pts1ed)",
   "dn33:2.2.109": "vigate → vighāte (pts1ed)",
   "dn33:2.2.117": "upekkhako → upekkhako ca (bj, sya-all, mr); upekhako (pts1ed)",
-  "dn33:2.3.45": "satisambojjhaṅgaṁ bhāve",
   "dn33:3.1.47": "gilānā vuṭṭhito → gilānavuṭṭhito (saddanīti)",
   "dn33:3.1.99": "paccāsīsati → paccāsiṁsati (bj, sya-all, km, pts1ed)",
   "dn33:3.1.109": "cātumahārājikā → cātummahārājikā (bj, sya-all, pts1ed)",


### PR DESCRIPTION
An incorrect segment in a variant file was causing this error when running `bilara_check_variant`:

```
[get_unknown_variants] There are '1' uids that are not validated
[get_unknown_variants] Not valid keys: 
{'dn33:2.3.45': 'satisambojjhaṅgaṁ bhāve'}
```