### PR TITLE
Remove the -e (--editable) flag from the pip install command

### DIFF
--- a/.github/workflows/bilara-data-changed-files-to-sc-data.yml
+++ b/.github/workflows/bilara-data-changed-files-to-sc-data.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up sutta-processor
         if: steps.related-changed-files.outputs.RELATED_FILES
-        run: pip install -e .
+        run: pip install .
         working-directory: bilara-data-integrity
 
       - name: Install bilara-data Python dependencies


### PR DESCRIPTION
I was wrong about the cache pip being the problem, even though setup.py was failing because of not being able to find pip.  However, we're also getting this error:

Build backend does not support editables, falling back to setup.py egg_info.
Preparing metadata (setup.py): started
Preparing metadata (setup.py): finished with status 'error'

Which is related to building Sutta Processor with -e (--editable).  So I'm removing that to make it non-editable.