### PR TITLE
Remov print statement that executed before the exit.

### DIFF
--- a/.github/workflows/get_related_files.py
+++ b/.github/workflows/get_related_files.py
@@ -90,5 +90,4 @@ if __name__ == '__main__':
     try:
         get_related_files(file_paths=args.files)
     except Exception as e:
-        print(f'The Python script raised an exception: {e}')
         sys.exit(1)


### PR DESCRIPTION
A print statement before the sys.exit() call was causing the workflow step to finish prematurely and not fail the GA.