### PR TITLE
Remove stray comment from html

### DIFF
--- a/html/pli/ms/vinaya/pli-tv-bu-vb/pli-tv-bu-vb-pc/pli-tv-bu-vb-pc14_html.json
+++ b/html/pli/ms/vinaya/pli-tv-bu-vb/pli-tv-bu-vb-pc/pli-tv-bu-vb-pc14_html.json
@@ -54,7 +54,7 @@
   "pli-tv-bu-vb-pc14:2.2.1": "<p>{}",
   "pli-tv-bu-vb-pc14:2.2.2": "{}",
   "pli-tv-bu-vb-pc14:2.2.3": "{}</p>",
-  "pli-tv-bu-vb-pc14:2.2.4": "<p>_Cimilikā_. Sp.2.112(VRI): _Cimilikā nāma sudhādiparikammakatāya bhūmiyā vaṇṇānurakkhaṇatthaṁ katā hoti, taṁ heṭṭhā pattharitvā upari kaṭasārakaṁ pattharanti_—“A _cimilikā_ is made to protect the color of a floor that has been plastered, etc. It is spread out underneath, with a straw-mat spread out on top.” {}</p>",
+  "pli-tv-bu-vb-pc14:2.2.4": "<p>{}</p>",
   "pli-tv-bu-vb-pc14:2.2.5": "<p>{}",
   "pli-tv-bu-vb-pc14:2.2.6": "{}",
   "pli-tv-bu-vb-pc14:2.2.7": "{}",


### PR DESCRIPTION
Somehow a comment ended up in an html file.  Unless there's some other funny business I'm not seeing, hoping this straightforward fix is all it needs.  The comment itself properly exists in the right place already.