### PR TITLE
remove useless link in license

### DIFF
--- a/root/en/site/publication_root-en-site.json
+++ b/root/en/site/publication_root-en-site.json
@@ -19,6 +19,6 @@
   "publication:source": "Source",
   "publication:suttaCentralPublicationNumber": "SuttaCentral publication number",
   "publication:license": "License",
-  "publication:licenseDescription": "To the extent possible under law, <a rel='dct:publisher' href='https://suttacentral.net/'><span property='dct:title'>{authorName}</span></a> has waived all copyright and related or neighboring rights to <cite property='dct:title'>{translationTitle}</cite>. This work is published from <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australia</span>.",
+  "publication:licenseDescription": "To the extent possible under law, <span property='dct:title'>{authorName}</span> has waived all copyright and related or neighboring rights to <cite property='dct:title'>{translationTitle}</cite>. This work is published from <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australia</span>.",
   "publication:aboutThisLicense": "About this license"
 }

--- a/translation/de/site/publication_translation-de-site.json
+++ b/translation/de/site/publication_translation-de-site.json
@@ -2,7 +2,7 @@
   "publication:aboutThisLicense": "Über diese Lizenz ",
   "publication:edition": "Ausgabe ",
   "publication:license": "Lizenz ",
-  "publication:licenseDescription": "Soweit gesetzlich möglich hat <a rel='dct:publisher' href='https://suttacentral.net/'><span property='dct:title'>{authorName}</span></a> auf jedes Copyright und alle verwandten Rechte an <cite property='dct:title'>{translationTitle}</cite> verzichtet. Dises Werk wurde von <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australien </span>aus publiziert. ",
+  "publication:licenseDescription": "Soweit gesetzlich möglich hat <span property='dct:title'>{authorName}</span> auf jedes Copyright und alle verwandten Rechte an <cite property='dct:title'>{translationTitle}</cite> verzichtet. Dises Werk wurde von <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australien </span>aus publiziert. ",
   "publication:numberOfVolumes": "Anzahl der Bände ",
   "publication:publicationDate": "Datum der Publikation ",
   "publication:publicationStatus": "Status der Publikation ",

--- a/translation/fr/site/publication_translation-fr-site.json
+++ b/translation/fr/site/publication_translation-fr-site.json
@@ -2,7 +2,7 @@
   "publication:aboutThisLicense": "À propos de cette licence ",
   "publication:edition": "Édition ",
   "publication:license": "Licence ",
-  "publication:licenseDescription": "Dans la mesure où la loi le permet, <a rel='dct:publisher' href='https://suttacentral.net/'><span property='dct:title'>{authorName}</span></a> a renoncé à tous les droits d'auteur et droits connexes ou voisins de <cite property='dct:title'>{translationTitle}</cite>. Ce travail est publié depuis l’<span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australie</span>. ",
+  "publication:licenseDescription": "Dans la mesure où la loi le permet, <span property='dct:title'>{authorName}</span> a renoncé à tous les droits d'auteur et droits connexes ou voisins de <cite property='dct:title'>{translationTitle}</cite>. Ce travail est publié depuis l’<span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australie</span>. ",
   "publication:numberOfVolumes": "Nombre de volumes ",
   "publication:publicationDate": "Date de publication ",
   "publication:publicationStatus": "État de la publication ",

--- a/translation/my/site/publication_translation-my-site.json
+++ b/translation/my/site/publication_translation-my-site.json
@@ -19,6 +19,6 @@
   "publication:source": "မူရင်း",
   "publication:suttaCentralPublicationNumber": "SuttaCentral စာစောင်နံပါတ်",
   "publication:license": "လိုင်စင်",
-  "publication:licenseDescription": "ဥပဒေမှ ခွင့်ပြုထားသော အတိုင်းအတာအထိ <a rel='dct:Publisher' href='https://suttacentral.net/'><span property='dct:title'>{authorName}</span></a> သည် <cite property='dct:title'>{translationTitle}</cite> ကို မူလမူပိုင်များ သို့မဟုတ် မူပိုင်များနှင့် ဆက်နွယ်သူများနှင့် ပါတ်သက်သော အခွံကြေးငွေများကို ကင်းလွတ်ခွင့်ပြုပါသည်။ ယခုထုတ်ဝေမှုသည် <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australia</span> မှဖြစ်ပါသည်။",
+  "publication:licenseDescription": "ဥပဒေမှ ခွင့်ပြုထားသော အတိုင်းအတာအထ<span property='dct:title'>{authorName}</span>a> သည် <cite property='dct:title'>{translationTitle}</cite> ကို မူလမူပိုင်များ သို့မဟုတ် မူပိုင်များနှင့် ဆက်နွယ်သူများနှင့် ပါတ်သက်သော အခွံကြေးငွေများကို ကင်းလွတ်ခွင့်ပြုပါသည်။ ယခုထုတ်ဝေမှုသည် <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australia</span> မှဖြစ်ပါသည်။",
   "publication:aboutThisLicense": "ယခုလိုင်စင်အကြောင်း"
 }

--- a/translation/no/site/publication_translation-no-site.json
+++ b/translation/no/site/publication_translation-no-site.json
@@ -19,6 +19,6 @@
   "publication:source": "Kilde",
   "publication:suttaCentralPublicationNumber": "SuttaCentral utgivelsesnummer",
   "publication:license": "Lisens",
-  "publication:licenseDescription": "I den grad det er lovmessig tillatt, har <a rel='dct:publisher' href='https://suttacentral.net/'><span property='dct:title'>{authorName}</span></a> gitt avkall på all opphavsrett og relaterte eller tilstøtende rettigheter til <cite property='dct:title'>{translationTitle}</cite>. Dette verket er publisert fra <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australia</span>.",
+  "publication:licenseDescription": "I den grad det er lovmessig tillatt, har <span property='dct:title'>{authorName}</span> gitt avkall på all opphavsrett og relaterte eller tilstøtende rettigheter til <cite property='dct:title'>{translationTitle}</cite>. Dette verket er publisert fra <span property='vcard:Country' datatype='dct:ISO3166' content='AU' about='https://suttacentral.net/licensing'>Australia</span>.",
   "publication:aboutThisLicense": "Om denne lisensen"
 }


### PR DESCRIPTION
As mentioned in this issue: https://github.com/suttacentral/suttacentral/issues/2995

The only thing I'm slightly unsure about is `rel='dct:publisher'` that was in the <a> tag.