### PR TITLE
Add two localized segments.

### DIFF
--- a/root/en/site/interface_root-en-site.json
+++ b/root/en/site/interface_root-en-site.json
@@ -150,5 +150,7 @@
   "text:segmentNumber": "SuttaCentral segment number",
   "text:viewImage": "View page image",
   "interface:previous": "Previous",
-  "interface:next": "Next"
+  "interface:next": "Next",
+  "interface:navigationTitle": "Navigation",
+  "interface:parallelsTitle": "Suttas and Parallels"
 }


### PR DESCRIPTION
I have tested these locally. This https://github.com/suttacentral/suttacentral/pull/3101 pr must be accepted for them to be used.

They are for page titles. Suttaplex pages:

![image](https://github.com/suttacentral/bilara-data/assets/82448383/87687e71-e4f5-424c-9c9c-425fb092d3a2)

And navigation pages:

![image](https://github.com/suttacentral/bilara-data/assets/82448383/e9213bc7-4654-467e-9ef0-4021ea9a8b93)

I have checked the repo for occurrences of `—` and there don't seem to be any more hard coded English page titles.