### PR TITLE
Fix typo in sn44.2:17.7 EN Sujato: "bu" -> "by"

### DIFF
--- a/translation/en/sujato/sutta/sn/sn44/sn44.2_translation-en-sujato.json
+++ b/translation/en/sujato/sutta/sn/sn44/sn44.2_translation-en-sujato.json
@@ -91,7 +91,7 @@
   "sn44.2:17.4": "“What do you think, Anurādha? ",
   "sn44.2:17.5": "Do you regard a realized one as without form, feeling, perception, choices, and consciousness?” ",
   "sn44.2:17.6": "“No, sir.” ",
-  "sn44.2:17.7": "“In that case, Anurādha, since a realized one is not found bu you as a genuine fact in this very life, is it cogent for you to declare: ",
+  "sn44.2:17.7": "“In that case, Anurādha, since a realized one is not found by you as a genuine fact in this very life, is it cogent for you to declare: ",
   "sn44.2:17.8": "‘Reverends, when a realized one is describing a realized one—a supreme person, highest of people, who has reached the highest point—they describe them other than these four ways: ",
   "sn44.2:17.9": "After death, a realized one still exists, or no longer exists, or both still exists and no longer exists, or neither still exists nor no longer exists’?” ",
   "sn44.2:17.10": "",


### PR DESCRIPTION
### Summary

Just stumbled upon this while reading SN 44.2 myself, figured I could contribute a quick fix

### Details

- "bu" is not a word in English, so there is a typo. the word "by" is only one letter off and fits within the sentence structure, so seems like the intended word


### Misc

I'm a professional software engineer with a variety of experience in different stacks (see my profile et al) and FOSS contributor and maintainer, so if there's any low-hanging purely technical things y'all could use some help with, feel free to ask me for help. SuttaCentral is currently my most-used site for reading the Pali canon, so I appreciate all the work that's gone into it, the friendly mobile layout, the various translations hosted, the search, et al, and that's it's open source here!

There wasn't a CONTRIBUTING.md in any of the repos and the activity level seems to vary, so I wasn't sure what kinds of contributions might be acceptable. Some low-hanging fruit I saw were: adding [the CC0 license from the site](https://suttacentral.net/licensing?lang=en) as LICENSE files in the repos, some 'legacy' HTML translations available in the issues on the `sc-data` repo but not yet incorporated into the website, and updating/maintaining some of the dependencies and dev tooling

**Updates**: 
- [x] see #4753 regarding LICENSE.md
- [x] see 8bd8373f443696f0f8f14b48ca7de5afe2024a37 regarding CONTRIBUTING.md