### PR TITLE
add LICENSE.md file to reference site Licensing page

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,1 @@
+See https://suttacentral.net/licensing


### PR DESCRIPTION
### Summary

I noticed LICENSE files were missing in the main repositories despite the website having an [explicit page on licensing](https://suttacentral.net/licensing). This was something I mentioned in #4739 

### Details

- add `LICENSE.md` file to be explicit in all repositories about licensing
  - the licensing details have otherwise already existed and are often made explicit with translators etc, this just places a reference directly in the repo

#### Verification

Here's a screenshot of the License tab this adds (as can be seen on my branch):
<img width="956" height="228" alt="Screenshot 2025-12-31 at 4 26 05 PM" src="https://github.com/user-attachments/assets/5d468525-4729-472c-a2a0-ce11ae5d24c6" />

Once merged to the default branch (`published` in this case), it will also add a "View License" button under the "About":
<img width="318" height="212" alt="Screenshot 2025-12-31 at 4 37 33 PM" src="https://github.com/user-attachments/assets/8a8a9a1f-e343-4f69-96e5-bfb2f8ab1c6f" />

  
### Future Work

For more explicitness, if desired:
1. [x] ~this file could be updated to either contain the full text or partial text based on what is relevant to each repository~
    - Done in https://github.com/suttacentral/bilara-data/commit/2dec63b2ba200a3540e8ec78614105b47fed5318
1. [x] ~Licensing details could be mentioned per directory as well if applicable~
     - Not necessary since single license applies to this repo
1. [ ] License headers could be added per-file