### PR TITLE
Add initial entries for `viewoption:ptsRefs` (EN, RU, ES)

### DIFF
--- a/root/en/site/viewoption_root-en-site.json
+++ b/root/en/site/viewoption_root-en-site.json
@@ -26,6 +26,8 @@
   "viewoption:notesDescription": "See translator's notes, variant readings, etc..",
   "viewoption:paliLookupDictionaryDisabled": "The Pali lookup dictionary is now disabled.",
   "viewoption:plain": "Plain",
+  "viewoption:ptsRefsEnabled": "PTS references are now enabled.",
+  "viewoption:ptsRefsDisabled": "PTS references are now disabled.",
   "viewoption:reference": "References",
   "viewoption:referenceDescription": "“Main” displays the primary SuttaCentral references for segmented texts, and all references for other texts. Remaining items are extra Pali editions.",
   "viewoption:referenceDisplayTypeMain": "Main",

--- a/translation/es/site/viewoption_translation-es-site.json
+++ b/translation/es/site/viewoption_translation-es-site.json
@@ -26,6 +26,8 @@
   "viewoption:notesDescription": "Ver notas del traductor, lecturas variantes, etc.",
   "viewoption:paliLookupDictionaryDisabled": "El diccionario de búsqueda de Pali ahora está deshabilitado.",
   "viewoption:plain": "Plano",
+  "viewoption:ptsRefsEnabled": "PTS referencias ahora están habilitadas.",
+  "viewoption:ptsRefsDisabled": "PTS referencias ahora están deshabilitadas.",
   "viewoption:reference": "Referencias",
   "viewoption:referenceDescription": "“Principal” muestra las referencias primarias de SuttaCentral para textos segmentados y todas las referencias para otros textos. Los elementos restantes son ediciones adicionales de Pali.",
   "viewoption:referenceDisplayTypeMain": "Principal",

--- a/translation/ru/site/viewoption_translation-ru-site.json
+++ b/translation/ru/site/viewoption_translation-ru-site.json
@@ -26,6 +26,8 @@
   "viewoption:notesDescription": "Показывать заметки переводчика, варианты прочтений и т.д.",
   "viewoption:paliLookupDictionaryDisabled": "Словарь поиска пали отключен.",
   "viewoption:plain": "Простой",
+  "viewoption:ptsRefsEnabled": "Включены PTS ссылки.",
+  "viewoption:ptsRefsDisabled": "PTS ссылки скрыты.",
   "viewoption:reference": "Ссылки",
   "viewoption:referenceDescription": "Опция «Основные» отображает основные ссылки SuttaCentral для сегментированных текстов и все ссылки для других текстов. Другие опции — ссылки разных палийских редакций.",
   "viewoption:referenceDisplayTypeMain": "Основные",


### PR DESCRIPTION
## Summary

Add EN root and ES and RU translation entries for `viewoption:ptsRefs`

## Details

#### fix: add root entries for `viewoption:ptsRefs`

- this has been reported as a bug at [least](https://discourse.suttacentral.net/t/suttacentral-bug-reports/27763/340?u=agilgur5) [twice](https://discourse.suttacentral.net/t/suttas-sprinkled-with-empty-notes-on-variant/45040/16?u=agilgur5) on the forum (probably more)
  - now that I know where these are sourced from, I can add them myself -- but see note below
  - the localization keys for these are located [in the `TopSheetViews` component]( https://github.com/suttacentral/suttacentral/blob/41573627fbdb949daafde9112a73d07406c4ff3a/client/elements/addons/sc-top-sheet-views.js#L771)

- note that I followed the existing ordering, which is _partially_ alphabetical:
  - `ptsRefs` is in alphabetical order
  - but `Enabled` is before `Disabled`, as it is for other entries like `mainRefs` and `allRefs`
    - (IMO, everything should be automatically fully alphabetized, but that's a separate change)
    
#### feat: add ES and RU translations for `viewoption:ptsRefs` 

- I have some proficiency in both languages and used the existing words from other lines for the translation

## Notes to Reviewers

This should probably be done from the Bilara app, especially if [empty strings](https://github.com/suttacentral/bilara-data/commit/2e789b96da67d76c01d40093b72cb1fa3625e6df) will be added for all other languages with this change. I don't have access to Bilara at this time, but can help with some of these simpler interface translations